### PR TITLE
Refactor: Update default theme colors and confirm settings preservation

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -79,7 +79,7 @@ function my_growth_tools_setup() {
 		apply_filters(
 			'my_growth_tools_custom_background_args',
 			array(
-				'default-color' => 'ffffff',
+				'default-color' => 'F9FAFB',
 				'default-image' => '',
 			)
 		)
@@ -114,22 +114,22 @@ function my_growth_tools_setup() {
 		array(
 			'name'  => esc_html__( 'Primary', 'my-growth-tools' ),
 			'slug'  => 'primary',
-			'color' => '#ff3366',
+			'color' => '#2DD4BF',
 		),
 		array(
 			'name'  => esc_html__( 'Secondary', 'my-growth-tools' ),
 			'slug'  => 'secondary',
-			'color' => '#3366ff',
+			'color' => '#3B82F6',
 		),
 		array(
-			'name'  => esc_html__( 'Dark Gray', 'my-growth-tools' ),
-			'slug'  => 'dark-gray',
-			'color' => '#333333',
+			'name'  => esc_html__( 'Text Color', 'my-growth-tools' ),
+			'slug'  => 'text-color',
+			'color' => '#374151',
 		),
 		array(
-			'name'  => esc_html__( 'Light Gray', 'my-growth-tools' ),
-			'slug'  => 'light-gray',
-			'color' => '#f9f9f9',
+			'name'  => esc_html__( 'Background Color', 'my-growth-tools' ),
+			'slug'  => 'background-color',
+			'color' => '#F9FAFB',
 		),
 		array(
 			'name'  => esc_html__( 'White', 'my-growth-tools' ),

--- a/inc/custom-header.php
+++ b/inc/custom-header.php
@@ -17,7 +17,7 @@ function my_growth_tools_custom_header_setup() {
 			'my_growth_tools_custom_header_args',
 			array(
 				'default-image'      => '',
-				'default-text-color' => '000000',
+				'default-text-color' => '111827',
 				'width'              => 1200,
 				'height'             => 250,
 				'flex-height'        => true,

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -36,7 +36,7 @@ function my_growth_tools_customize_register( $wp_customize ) {
 	$wp_customize->add_setting(
 		'primary_color',
 		array(
-			'default'           => '#ff3366',
+			'default'           => '#2DD4BF',
 			'sanitize_callback' => 'sanitize_hex_color',
 			'transport'         => 'postMessage',
 		)
@@ -57,7 +57,7 @@ function my_growth_tools_customize_register( $wp_customize ) {
 	$wp_customize->add_setting(
 		'secondary_color',
 		array(
-			'default'           => '#3366ff',
+			'default'           => '#3B82F6',
 			'sanitize_callback' => 'sanitize_hex_color',
 			'transport'         => 'postMessage',
 		)
@@ -78,7 +78,7 @@ function my_growth_tools_customize_register( $wp_customize ) {
 	$wp_customize->add_setting(
 		'text_color',
 		array(
-			'default'           => '#333333',
+			'default'           => '#374151',
 			'sanitize_callback' => 'sanitize_hex_color',
 			'transport'         => 'postMessage',
 		)
@@ -424,9 +424,9 @@ add_action( 'customize_preview_init', 'my_growth_tools_customize_preview_js' );
  * Generate CSS for the color customization options.
  */
 function my_growth_tools_customizer_css() {
-	$primary_color = get_theme_mod( 'primary_color', '#ff3366' );
-	$secondary_color = get_theme_mod( 'secondary_color', '#3366ff' );
-	$text_color = get_theme_mod( 'text_color', '#333333' );
+	$primary_color = get_theme_mod( 'primary_color', '#2DD4BF' );
+	$secondary_color = get_theme_mod( 'secondary_color', '#3B82F6' );
+	$text_color = get_theme_mod( 'text_color', '#374151' );
 	
 	$css = '
 		:root {


### PR DESCRIPTION
This commit implements the following changes:

1.  **Update Default Theme Colors:**
    *   I modified `inc/customizer.php` to set new default values for:
        *   `primary_color`: #2DD4BF
        *   `secondary_color`: #3B82F6
        *   `text_color`: #374151
    *   I modified `functions.php` to:
        *   Set the default for `custom-background` to #F9FAFB.
        *   Update the `editor-color-palette` to reflect the new primary, secondary, text, and background default colors for consistency in the Gutenberg editor.
    *   I modified `inc/custom-header.php` to set the default `header_text_color` to #111827.
    *   These changes affect new installations or users who reset settings; they do not override existing user-configured colors.

2.  **Settings Preservation:**
    *   I reviewed theme files (`functions.php`, `inc/` directory) for hooks like `after_switch_theme` or direct option overrides that could cause your settings to reset on theme update/reactivation.
    *   No such problematic code was found. The theme uses standard WordPress Customizer defaults, which respect saved user settings. The cause of any reported settings reset is likely external to the theme's core logic.

The theme is now updated with the new default color scheme and is structured to preserve your configurations during standard WordPress operations.